### PR TITLE
Next

### DIFF
--- a/rspec-maven-plugin/src/main/ruby/de/saumya/mojo/rspec/rspec1/maven_console_progress_formatter.rb
+++ b/rspec-maven-plugin/src/main/ruby/de/saumya/mojo/rspec/rspec1/maven_console_progress_formatter.rb
@@ -65,6 +65,32 @@ class MavenConsoleProgressFormatter < Spec::Runner::Formatter::BaseFormatter
     pass_count = example_count - ( failure_count + pending_count ) 
     MOJO_LOG.info( "=========================================" )
     MOJO_LOG.info( "TOTAL: #{pass_count} passing; #{failure_count} failing; #{pending_count} pending")
+
+	# Creating the XML report
+	report_dir = "#{BASE_DIR}/target"
+    FileUtils.mkdir_p report_dir
+    report_filename = "#{report_dir}/TEST-Ruby.xml"
+    content = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+<testsuite failures=\"#{failure_count}\" time=\"#{duration}\" errors=\"0\" skipped=\"#{pending_count}\" tests=\"#{example_count}\" name=\"Ruby\">\n"
+
+	# Passing
+	@passing.each { |test|
+		content = content + "<testcase time=\"0.0\" name=\"#{test.description}\"/>\n"
+	}
+	
+	# Pending - considering as failures
+	@pending.each { |test|
+		content = content + "<testcase time=\"0.0\" name=\"#{test.description}\"><failure></failure></testcase>\n"
+	}
+	
+	# Failures
+	@failing.each { |test|
+		content = content + "<testcase time=\"0.0\" name=\"#{test.description}\"><failure></failure></testcase>\n"
+	}
+	
+	content = content + "</testsuite>"
+
+    File.open(report_filename, 'w+') {|f| f.write(content) }
   end
   
 end

--- a/rspec-maven-plugin/src/main/ruby/de/saumya/mojo/rspec/rspec2/maven_console_progress_formatter.rb
+++ b/rspec-maven-plugin/src/main/ruby/de/saumya/mojo/rspec/rspec2/maven_console_progress_formatter.rb
@@ -145,6 +145,34 @@ class MavenConsoleProgressFormatter < RSpec::Core::Formatters::BaseFormatter
     end
     
     puts ""
+
+	# Creating the XML report
+	report_dir = "#{BASE_DIR}/target"
+    FileUtils.mkdir_p report_dir
+    report_filename = "#{report_dir}/TEST-Ruby.xml"
+    content = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+<testsuite failures=\"#{failure_count}\" time=\"#{duration}\" errors=\"0\" skipped=\"#{pending_count}\" tests=\"#{example_count}\" name=\"Ruby\">\n"
+
+    @batches.each do |batch|
+      # Passing
+      batch.passing.each { |test|
+        content = content + "<testcase time=\"0.0\" name=\"#{test.description}\"/>\n"
+      }
+
+      # Pending - considering as failures
+      batch.pending.each { |test|
+        content = content + "<testcase time=\"0.0\" name=\"#{test.description}\"><failure></failure></testcase>\n"
+      }
+
+      # Failures
+      batch.failing.each { |test|
+        content = content + "<testcase time=\"0.0\" name=\"#{test.description}\"><failure></failure></testcase>\n"
+      }
+    end
+
+	content = content + "</testsuite>"
+
+    File.open(report_filename, 'w+') {|f| f.write(content) }
   end
   
 =begin


### PR DESCRIPTION
Hello,
the commits makes the maven reports generate a TEST-Ruby.xml file, which is in JUnit format. We are feeding this to TeamCity (using maven-antrun-plugin which runs:

```
 <echo message="##teamcity[importData type='junit' path='${project.build.directory}/TEST-Ruby.xml']" />
```

before the tests start), so that our tests are counted and we can see which passed/failed. I think other tools may consume this format as well.

Adam
