### PR TITLE
Not sure why we're tracking duration separately from the example itself, 

### DIFF
--- a/rspec-maven-plugin/src/main/ruby/de/saumya/mojo/rspec/rspec2/maven_console_progress_formatter.rb
+++ b/rspec-maven-plugin/src/main/ruby/de/saumya/mojo/rspec/rspec2/maven_console_progress_formatter.rb
@@ -1,4 +1,3 @@
-
 require 'rspec/core/formatters/base_formatter'
 
 class MavenConsoleProgressFormatter < RSpec::Core::Formatters::BaseFormatter
@@ -59,7 +58,6 @@ class MavenConsoleProgressFormatter < RSpec::Core::Formatters::BaseFormatter
   
   def example_started(example)
     super
-    example.metadata[:started_at] = Time.now
     example.metadata[:spec_file_path] = current_file
     set_location( example.metadata )
     node = example.metadata[:example_group]
@@ -87,7 +85,7 @@ class MavenConsoleProgressFormatter < RSpec::Core::Formatters::BaseFormatter
   end
   
   def example_completed(example, status=nil)
-    elapsed = Time.now - example.metadata[:started_at]
+    elapsed = Time.now - example.metadata[:execution_result][:started_at]
     print " - #{elapsed}s"
     
     if ( status )


### PR DESCRIPTION
Not sure why we're tracking duration separately from the example itself, which already maintains it in its metadata[:execution_result].  This change is required when reporting example results over DRb, in which the example passed at start, isn't necessarily the same one passed at finished.
