### PR TITLE
Default value for result message on RSpecMojo

### DIFF
--- a/rspec-maven-plugin/src/main/java/de/saumya/mojo/rspec/RSpecMojo.java
+++ b/rspec-maven-plugin/src/main/java/de/saumya/mojo/rspec/RSpecMojo.java
@@ -170,7 +170,6 @@ public class RSpecMojo extends AbstractTestMojo {
         new File(reportPath).renameTo(reportFile);
 
         Result result = new Result();
-		result.message = "An unknown error occurred.";
         Reader in = null;
         try {
             in = new FileReader(reportFile);
@@ -201,7 +200,13 @@ public class RSpecMojo extends AbstractTestMojo {
                 }
             }
         }
-        result.success = result.message.contains("0 failures");
+
+		if (result.message == null) {
+			result.message = "An unknown error occurred";
+			result.success = false;
+		}
+        else
+			result.success = result.message.contains("0 failures");
         return result;
     }
 


### PR DESCRIPTION
RSpecMojo has a small bug on the calculation of success or failure: it is possible for RSpecMojo.runIt to execute without ever assigning a value to its JRubyRun.Result.message instance, since a message value is only assigned if RSpecMojo finds a line containing the words "failure" and "example". If that happens, it will cause an NPE when calculating success on the last line of that method.

The fix creates a default message ("An unknown error occurred" and sets the result success flag to false.
