### PR TITLE
Fix ArgumentError when running rspec maven with rspec 2.11.0.

### DIFF
--- a/rspec-maven-plugin/src/it/rspec-path/invoker.properties
+++ b/rspec-maven-plugin/src/it/rspec-path/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals = rspec:test
+invoker.mavenOpts = -client

--- a/rspec-maven-plugin/src/it/rspec-path/pom.xml
+++ b/rspec-maven-plugin/src/it/rspec-path/pom.xml
@@ -1,0 +1,37 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                      http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>de.saumya.mojo</groupId>
+  <artifactId>spec-success</artifactId>
+  <version>testing</version>
+
+  <repositories>
+    <repository>
+      <id>rubygems-releases</id>
+      <url>http://rubygems-proxy.torquebox.org/releases</url>
+    </repository>
+  </repositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>rubygems</groupId>
+      <artifactId>rspec</artifactId>
+      <version>2.11.0</version>
+      <type>gem</type>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>rspec-maven-plugin</artifactId>
+	<version>@project.version@</version>
+        <extensions>true</extensions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/rspec-maven-plugin/src/it/rspec-path/spec/success_spec.rb
+++ b/rspec-maven-plugin/src/it/rspec-path/spec/success_spec.rb
@@ -1,0 +1,6 @@
+describe "succeeding spec" do
+
+  it "should succeed" do
+  end
+
+end

--- a/rspec-maven-plugin/src/it/rspec-path/test.properties
+++ b/rspec-maven-plugin/src/it/rspec-path/test.properties
@@ -1,0 +1,4 @@
+jruby.18and19=true
+# to allow the verify script to work
+#jruby.version=1.7.0.preview2
+jruby.version=1.6.7.2

--- a/rspec-maven-plugin/src/it/rspec-path/verify.bsh
+++ b/rspec-maven-plugin/src/it/rspec-path/verify.bsh
@@ -1,0 +1,16 @@
+import java.io.*;
+import org.codehaus.plexus.util.FileUtils;
+
+
+String log = FileUtils.fileRead( new File( basedir, "build.log" ) );
+String expected = "mode 1.8: 1 example, 0 failures";
+if ( !log.contains( expected ) )
+{
+    throw new RuntimeException( "log file does not contain '" + expected + "'" );
+}
+
+expected = "mode 1.9: 1 example, 0 failures";
+if ( !log.contains( expected ) )
+{
+    throw new RuntimeException( "log file does not contain '" + expected + "'" );
+}


### PR DESCRIPTION
When running rspec-maven-plugin with rspec 2.11.0, rspec returns a relative path
to the example file, causing Pathname.relative_path_from to fail in the maven
console formatter.
