### PR TITLE
Adding an attribute called includeRubygemsInResources

### DIFF
--- a/gem-maven-plugin/src/it/include-rubygems-in-resources/pom.xml
+++ b/gem-maven-plugin/src/it/include-rubygems-in-resources/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>include-rubygems-in-resources</artifactId>
+    <version>testing</version>
+    <packaging>jar</packaging>
+
+    <repositories>
+        <repository>
+            <id>rubygems-release</id>
+            <url>http://rubygems-proxy.torquebox.org/releases</url>
+        </repository>
+    </repositories>
+    <dependencies>
+        <dependency>
+            <groupId>rubygems</groupId>
+            <artifactId>sass</artifactId>
+            <version>3.2.7</version>
+            <type>gem</type>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.8.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jruby</groupId>
+            <artifactId>jruby-complete</artifactId>
+            <version>1.7.3</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>de.saumya.mojo</groupId>
+                <artifactId>gem-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <includeRubygemsInResources>true</includeRubygemsInResources>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>initialize</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/gem-maven-plugin/src/it/include-rubygems-in-resources/src/main/java/com/example/javasass/JavaSassMain.java
+++ b/gem-maven-plugin/src/it/include-rubygems-in-resources/src/main/java/com/example/javasass/JavaSassMain.java
@@ -1,0 +1,19 @@
+package com.example.javasass;
+
+
+import org.jruby.embed.ScriptingContainer;
+
+public class JavaSassMain {
+
+    public static void main(String[] args) {
+        ScriptingContainer container = new ScriptingContainer();
+        container.runScriptlet("require 'rubygems'; require 'sass';");
+
+        String sass = ".test\n\tcolor: red";
+        container.put("str", sass);
+
+        String css = (String)container.runScriptlet("Sass::Engine.new(str).render");
+
+        System.out.println(css);
+    }
+}

--- a/gem-maven-plugin/src/main/java/de/saumya/mojo/gem/AbstractGemMojo.java
+++ b/gem-maven-plugin/src/main/java/de/saumya/mojo/gem/AbstractGemMojo.java
@@ -53,6 +53,15 @@ public abstract class AbstractGemMojo extends AbstractJRubyMojo {
      */
     protected boolean       includeRubygemsInTestResources;
 
+    /**
+     * flag whether to include all gems to resources, i.e. to classpath or not
+     * <br/>
+     * Command line -Dgem.includeRubygemsInResources=...
+     *
+     * @parameter expression="${gem.includeRubygemsInResources}" default-value="false"
+     */
+    protected boolean       includeRubygemsInResources;
+
     
     /**
      * flag whether to install rdocs of the used gems or not
@@ -300,6 +309,21 @@ public abstract class AbstractGemMojo extends AbstractJRubyMojo {
                 resource.addInclude("gems/**");
                 resource.addInclude("specifications/**");
                 project.getBuild().getTestResources().add(resource);
+            }
+        }
+
+        if (this.includeRubygemsInResources) {
+            for (File path : this.gemsConfig.getGemPath()) {
+                if (jrubyVerbose) {
+                    getLog().info("add gems to classpath from: "
+                            + path.getAbsolutePath());
+                }
+                // add it to the classpath so java classes can find the ruby files
+                Resource resource = new Resource();
+                resource.setDirectory(path.getAbsolutePath());
+                resource.addInclude("gems/**");
+                resource.addInclude("specifications/**");
+                project.getBuild().getResources().add(resource);
             }
         }
 


### PR DESCRIPTION
Hi!

This pull request has an attribute called includeRubygemsResources to add gems in the classpath. There is a issue open [here](https://github.com/torquebox/jruby-maven-plugins/issues/46#issuecomment-16451976).

:)
