### PR TITLE
Return 404 instead of 500 from the gem proxy when asked for files it doesn't have

### DIFF
--- a/gem-proxy/src/main/java/de/saumya/mojo/proxy/Controller.java
+++ b/gem-proxy/src/main/java/de/saumya/mojo/proxy/Controller.java
@@ -187,8 +187,12 @@ public class Controller {
                 if(filename.endsWith(SHA1) || filename.endsWith(".pom")){
                     File local = new File(localStorage, filename);
                     if(!local.exists()){
-                        if (!createFiles(parts[2], parts[3])){
-                            return new FileLocation(filename + " is being generated", Type.TEMP_UNAVAILABLE);
+                        try {
+                            if (!createFiles(parts[2], parts[3])){
+                                return new FileLocation(filename + " is being generated", Type.TEMP_UNAVAILABLE);
+                            }
+                        } catch (FileNotFoundException e) {
+                            return notFound("not found");
                         }
                     }
                     return new FileLocation(local, filename.endsWith(SHA1)? Type.ASCII_FILE: Type.XML_FILE);


### PR DESCRIPTION
This fixes URLs like http://rubygems-proxy.torquebox.org/releases/rubygems/warbler/1.4.1.dev/warbler-1.4.1.dev.pom to return a 404 instead of a 500. This change is already deployed to rubygems-proxy.torquebox.org.
