### PR TITLE
Gem isSnapshot should return true for any version that contains a letter...

### DIFF
--- a/gem-maven-plugin/src/main/java/de/saumya/mojo/gem/GemArtifact.java
+++ b/gem-maven-plugin/src/main/java/de/saumya/mojo/gem/GemArtifact.java
@@ -250,7 +250,7 @@ public class GemArtifact implements Artifact {
     }
 
     public boolean isSnapshot() {
-        return this.artifact.getVersion().matches("[a-zA-Z]");
+        return this.artifact.getVersion().matches(".*[a-zA-Z].*");
     }
 
     public void selectVersion(final String version) {


### PR DESCRIPTION
...,

not just a single letter..

I think this was the intention?

(seeing an issue where SNAPSHOT gems are attempting to publish to the RELEASE repo & getting rejected by Nexus.)
