### PR TITLE
Options to exclude maven classpath from gem-maven-plugin:exec

### DIFF
--- a/gem-maven-plugin/src/main/java/de/saumya/mojo/gem/AbstractGemMojo.java
+++ b/gem-maven-plugin/src/main/java/de/saumya/mojo/gem/AbstractGemMojo.java
@@ -232,7 +232,7 @@ public abstract class AbstractGemMojo extends AbstractJRubyMojo {
                             new GemScriptFactory(this.logger,
                                     this.classRealm, 
                                     null,
-                                    this.project.getTestClasspathElements(), 
+                                    getProjectClasspath(), 
                                     this.jrubyFork,
                                     this.gemsConfig):
                         (JRUBY_CORE.equals(artifact.getArtifactId()) ?
@@ -240,13 +240,13 @@ public abstract class AbstractGemMojo extends AbstractJRubyMojo {
                                   this.classRealm, 
                                   artifact.getFile(),
                                   resolveJRubyStdlibArtifact(artifact).getFile(),
-                                  this.project.getTestClasspathElements(), 
+                                  getProjectClasspath(), 
                                   this.jrubyFork, 
                                   this.gemsConfig) :
                     new GemScriptFactory(this.logger,
                                   this.classRealm, 
                                   artifact.getFile(),
-                                  this.project.getTestClasspathElements(), 
+                                  getProjectClasspath(), 
                                   this.jrubyFork, 
                                   this.gemsConfig));
                   

--- a/jruby-maven-plugin/pom.xml
+++ b/jruby-maven-plugin/pom.xml
@@ -78,6 +78,20 @@
 		    <ignore />
 		  </action>
 		</pluginExecution>
+		<pluginExecution>
+			<pluginExecutionFilter>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-plugin-plugin</artifactId>
+				<versionRange>[2.5.1,)</versionRange>
+				<goals>
+					<goal>helpmojo</goal>
+					<goal>descriptor</goal>
+				</goals>
+			</pluginExecutionFilter>
+			<action>
+				<ignore></ignore>
+			</action>
+		</pluginExecution>
 	      </pluginExecutions>
 	    </lifecycleMappingMetadata>
 	  </configuration>

--- a/jruby-maven-plugin/src/main/java/de/saumya/mojo/jruby/AbstractJRubyMojo.java
+++ b/jruby-maven-plugin/src/main/java/de/saumya/mojo/jruby/AbstractJRubyMojo.java
@@ -2,6 +2,8 @@ package de.saumya.mojo.jruby;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -142,6 +144,12 @@ public abstract class AbstractJRubyMojo extends AbstractMojo {
     protected MavenProject project;
 
     /**
+     * add project test class path to JVM classpath.
+     * @parameter default-value=true expression="${gem.addProjectClasspath}"
+     */
+    protected boolean addProjectClasspath;
+    
+    /**
      * local repository for internal use.
      *
      * @parameter default-value="${localRepository}"
@@ -197,7 +205,7 @@ public abstract class AbstractJRubyMojo extends AbstractMojo {
         }
         try {
 			ClassRealm realm = classRealm.getWorld().newRealm("jruby-all");
-			for (String path : this.project.getTestClasspathElements()) {
+			for (String path : getProjectClasspath()) {
 				realm.addConstituent(new File(path).toURI().toURL());
 			}
 			if (this.jrubyVersion != null) {
@@ -231,19 +239,19 @@ public abstract class AbstractJRubyMojo extends AbstractMojo {
                             new ScriptFactory(this.logger,
                                     this.classRealm, 
                                     null,
-                                    this.project.getTestClasspathElements(), 
+                                    getProjectClasspath(), 
                                     this.jrubyFork):
             			(JRUBY_CORE.equals(artifact.getArtifactId()) ?
                     new ScriptFactory(this.logger,
                             this.classRealm, 
                             artifact.getFile(),
                             resolveJRubyStdlibArtifact(artifact).getFile(),
-                            this.project.getTestClasspathElements(), 
+                            getProjectClasspath(), 
                             this.jrubyFork) :
                     new ScriptFactory(this.logger,
                             this.classRealm, 
                             artifact.getFile(),
-                            this.project.getTestClasspathElements(), 
+                            getProjectClasspath(), 
                             this.jrubyFork) );
 
             if(libDirectory != null && libDirectory.exists()){
@@ -394,5 +402,13 @@ public abstract class AbstractJRubyMojo extends AbstractMojo {
             }
         }
         throw new MojoExecutionException("failed to resolve jruby stdlib artifact");
+    }
+    
+    protected List<String> getProjectClasspath() throws DependencyResolutionRequiredException {
+    	if (addProjectClasspath) {
+    		return project.getTestClasspathElements();
+    	} else {
+    		return new ArrayList<String>();
+    	}
     }
 }

--- a/parent-mojo/pom.xml
+++ b/parent-mojo/pom.xml
@@ -75,6 +75,42 @@
         </executions>
       </plugin>
     </plugins>
+    <pluginManagement>
+    	<plugins>
+    		<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+    		<plugin>
+    			<groupId>org.eclipse.m2e</groupId>
+    			<artifactId>lifecycle-mapping</artifactId>
+    			<version>1.0.0</version>
+    			<configuration>
+    				<lifecycleMappingMetadata>
+    					<pluginExecutions>
+    						<pluginExecution>
+    							<pluginExecutionFilter>
+    								<groupId>
+    									org.apache.maven.plugins
+    								</groupId>
+    								<artifactId>
+    									maven-plugin-plugin
+    								</artifactId>
+    								<versionRange>
+    									[2.5.1,)
+    								</versionRange>
+    								<goals>
+    									<goal>helpmojo</goal>
+    									<goal>descriptor</goal>
+    								</goals>
+    							</pluginExecutionFilter>
+    							<action>
+    								<ignore></ignore>
+    							</action>
+    						</pluginExecution>
+    					</pluginExecutions>
+    				</lifecycleMappingMetadata>
+    			</configuration>
+    		</plugin>
+    	</plugins>
+    </pluginManagement>
   </build>
   <profiles>
     <profile>

--- a/rails3-maven-plugin/pom.xml
+++ b/rails3-maven-plugin/pom.xml
@@ -75,6 +75,20 @@
 		      <ignore />
 		    </action>
 		  </pluginExecution>
+		  <pluginExecution>
+		  	<pluginExecutionFilter>
+		  		<groupId>org.apache.maven.plugins</groupId>
+		  		<artifactId>maven-plugin-plugin</artifactId>
+		  		<versionRange>[2.5.1,)</versionRange>
+		  		<goals>
+		  			<goal>helpmojo</goal>
+		  			<goal>descriptor</goal>
+		  		</goals>
+		  	</pluginExecutionFilter>
+		  	<action>
+		  		<ignore></ignore>
+		  	</action>
+		  </pluginExecution>
 		</pluginExecutions>
 	      </lifecycleMappingMetadata>
 	    </configuration>

--- a/ruby-tools/pom.xml
+++ b/ruby-tools/pom.xml
@@ -140,6 +140,37 @@
 	</executions>
       </plugin>
     </plugins>
+    <pluginManagement>
+    	<plugins>
+    		<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+    		<plugin>
+    			<groupId>org.eclipse.m2e</groupId>
+    			<artifactId>lifecycle-mapping</artifactId>
+    			<version>1.0.0</version>
+    			<configuration>
+    				<lifecycleMappingMetadata>
+    					<pluginExecutions>
+    						<pluginExecution>
+    							<pluginExecutionFilter>
+    								<groupId>org.codehaus.mojo</groupId>
+    								<artifactId>
+    									exec-maven-plugin
+    								</artifactId>
+    								<versionRange>[1.2,)</versionRange>
+    								<goals>
+    									<goal>exec</goal>
+    								</goals>
+    							</pluginExecutionFilter>
+    							<action>
+    								<ignore></ignore>
+    							</action>
+    						</pluginExecution>
+    					</pluginExecutions>
+    				</lifecycleMappingMetadata>
+    			</configuration>
+    		</plugin>
+    	</plugins>
+    </pluginManagement>
   </build>
   <profiles>
     <profile> 


### PR DESCRIPTION
I got createprocess error=206 the filename or extension is too long when try to use gem-maven-plugin in javaee project. It's because we have very many dependencies and windows can't execute process with huge comand line. 

For fix this problem I added options to exclude (exactly, it's named add project classpath) to AbstractJRubyMojo. 

Example of usage:

```
			<plugin>
				<groupId>de.saumya.mojo</groupId>
				<artifactId>gem-maven-plugin</artifactId>
				<version>1.0.9-SNAPSHOT</version>
				<executions>
					<execution>
						<goals>
							<goal>exec</goal>
						</goals>
						<phase>generate-resources</phase>
						<configuration>
							<addProjectClasspath>false</addProjectClasspath>
							<skipGemInstall>true</skipGemInstall>
							<execArgs>${gem.home}\bin\compass compile
								${basedir}\src\main\sass
								--sass-dir ${basedir}\src\main\sass\
								--css-dir ${project.build.directory}\css</execArgs>
						</configuration>
					</execution>
				</executions>
				<dependencies>
					<dependency>
						<groupId>rubygems</groupId>
						<artifactId>compass</artifactId>
						<version>1.0.3</version>
						<type>gem</type>
					</dependency>
				</dependencies>
			</plugin>
```
