### PR TITLE
Adds compability with m2e (eclipse maven support)

### DIFF
--- a/jruby-maven-plugin/pom.xml
+++ b/jruby-maven-plugin/pom.xml
@@ -30,6 +30,12 @@
 	</exclusion>
       </exclusions>
     </dependency>
+
+	<dependency>
+		<groupId>org.sonatype.plexus</groupId>
+		<artifactId>plexus-build-api</artifactId>
+		<version>0.0.7</version>
+	</dependency>
   </dependencies>
   <build>
     <plugins>


### PR DESCRIPTION
### Summary
Adds support of m2e (plugin for Eclipse, that make integration between IDE and maven plugins). It's allow to add execution of gem-maven-plugin (and other children of JRubyAbstractMojo) to Eclipse incremental build with good perfomance and updating changed folders.

What is important:
* jruby will start only if folders in eclipseWatches has changes
* you can set folders that will be updated after jruby is called, so Eclipse will know about changes in filesystem.
It's very usefull if you use jruby for sass. 

It's not full solution, because required write configuration of support jruby-maven-plugins in m2e description, but I haven't time to make m2e connector. This is good compromise.

More about m2e compability is here: http://eclipse.org/m2e/documentation/m2e-making-maven-plugins-compat.html

### Example of usage

m2e configuration:

```
<pluginManagement>
	<plugins>
		<!--This plugin's configuration is used to store Eclipse m2e settings 
			only. It has no influence on the Maven build itself. -->
		<plugin>
			<groupId>org.eclipse.m2e</groupId>
			<artifactId>lifecycle-mapping</artifactId>
			<version>1.0.0</version>
			<configuration>
				<lifecycleMappingMetadata>
					<pluginExecutions>
						<pluginExecution>
							<pluginExecutionFilter>
								<groupId>
									de.saumya.mojo
								</groupId>
								<artifactId>
									gem-maven-plugin
								</artifactId>
								<versionRange>
									[1.0.9-SNAPSHOT,)
								</versionRange>
								<goals>
									<goal>exec</goal>
								</goals>
							</pluginExecutionFilter>
							<action>
								<execute>
									<runOnIncremental>true</runOnIncremental>
								</execute>
							</action>
						</pluginExecution>
					</pluginExecutions>
				</lifecycleMappingMetadata>
			</configuration>
		</plugin>
	</plugins>
</pluginManagement>
```

gem-maven-plugin settings:

```
<plugin>
	<groupId>de.saumya.mojo</groupId>
	<artifactId>gem-maven-plugin</artifactId>
	<version>1.0.9-SNAPSHOT</version>
	<executions>
		<execution>
			<id>default-cli</id>
			<goals>
				<goal>exec</goal>
			</goals>
			<phase>compile</phase>
			<configuration>
				<eclipseWatches>
					<folder>src/main/sass/</folder>
				</eclipseWatches>
				<eclipseRefresh>
 <!-- m2e-wtp add this folder to deployment assembly -->
					<folder>${project.build.directory}/m2e-wtp/web-resources/resources</folder>
				</eclipseRefresh>
				<addProjectClasspath>false</addProjectClasspath>
				<execArgs>${gem.home}\bin\compass ${sass.options}</execArgs>
				<jrubyFork>true</jrubyFork>
			</configuration>
		</execution>
	</executions>
	<dependencies>
		<dependency>
			<groupId>rubygems</groupId>
			<artifactId>compass</artifactId>
			<version>1.0.3</version>
			<type>gem</type>
		</dependency>
	</dependencies>
</plugin>
```
