### PR TITLE
Newer JRuby versions have more than 1 line to copy in the bin stubs

### DIFF
--- a/bundler-maven-plugin/src/main/java/de/saumya/mojo/bundler/InstallMojo.java
+++ b/bundler-maven-plugin/src/main/java/de/saumya/mojo/bundler/InstallMojo.java
@@ -176,12 +176,26 @@ public class InstallMojo extends AbstractGemMojo {
                     continue;
                 }
                 String[] lines = FileUtils.fileRead(f).split(sep);
+
+                final String stubSupplement;
+                if ("end".equals(lines[lines.length - 1])) {
+                    // extra stuff in there, we need the last 6 lines
+                    StringBuilder s = new StringBuilder();
+                    for (int i = lines.length - 6; i < lines.length; ++i) {
+                        s.append(lines[i].replaceFirst(", version", ""));
+                        s.append("\n");
+                    }
+                    stubSupplement = s.toString();
+                } else {
+                    stubSupplement = lines[lines.length - 1].replaceFirst(", version", "");
+                }
+
                 File binstubFile = new File(binStubs, f.getName());
                 if(!binstubFile.exists()){
                     if(jrubyVerbose){
                         getLog().info("create bin stub " + binstubFile);
                     }
-                    FileUtils.fileWrite(binstubFile, stub + lines[lines.length - 1].replaceFirst(", version", ""));
+                    FileUtils.fileWrite(binstubFile, stub + stubSupplement);
                     setExecutable(binstubFile);
                 }
             }


### PR DESCRIPTION
Newer jruby versions (9.1.13.0+) have more than 1 line in the bin executables that needs to be copied:

```
if Gem.respond_to?(:activate_bin_path)
load Gem.activate_bin_path('bundler', 'bundler')
else
gem "bundler"
load Gem.bin_path("bundler", "bundler")
end
```

This change copies the last 6 lines if necessary.