### PR TITLE
Drop unusupported rubyforge_project gemspec attr

### DIFF
--- a/gem-maven-plugin/src/main/java/de/saumya/mojo/gem/PackageMojo.java
+++ b/gem-maven-plugin/src/main/java/de/saumya/mojo/gem/PackageMojo.java
@@ -59,9 +59,6 @@ public class PackageMojo extends AbstractGemMojo {
     private String                    requirePaths;
 
     @Parameter
-    private String                    rubyforgeProject;
-
-    @Parameter
     private String                    rubygemsVersion;
 
     @Parameter
@@ -240,7 +237,6 @@ public class PackageMojo extends AbstractGemMojo {
         gemSpecWriter.append("bindir", this.bindir);
         gemSpecWriter.append("post_install_message", this.postInstallMessage);
 
-        gemSpecWriter.append("rubyforge_project", this.rubyforgeProject);
         gemSpecWriter.appendRdocFiles(this.extraRdocFiles);
         gemSpecWriter.appendFiles(this.extraFiles);
         gemSpecWriter.appendList("executables", this.executables);

--- a/ruby-tools/src/main/java/de/saumya/mojo/gems/spec/GemSpecification.java
+++ b/ruby-tools/src/main/java/de/saumya/mojo/gems/spec/GemSpecification.java
@@ -55,8 +55,6 @@ public class GemSpecification {
 
     private List<String>   requirements;
 
-    private String         rubyforge_project;
-
     private String         rubygems_version;
 
     private String         specification_version;
@@ -303,14 +301,6 @@ public class GemSpecification {
 
     public void setRequirements(final List<String> requirements) {
         this.requirements = requirements;
-    }
-
-    public String getRubyforge_project() {
-        return this.rubyforge_project;
-    }
-
-    public void setRubyforge_project(final String rubyforgeProject) {
-        this.rubyforge_project = rubyforgeProject;
     }
 
     public String getRubygems_version() {


### PR DESCRIPTION
This PR removes support for a defunct attribute.

The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property.

## Background

* [RubyForge was closed down in 2013][1].
* [rubygems/rubygems#2436 deprecated the `rubyforge_project` property][2].

[1]: https://twitter.com/evanphx/status/399552820380053505
[2]: rubygems/rubygems#2436

## Question for reviewer

- Is there anything else I should change or fix to make this work?