### PR TITLE
Make JRuby version checking more robust

### DIFF
--- a/ruby-tools/src/main/java/de/saumya/mojo/ruby/script/ScriptFactory.java
+++ b/ruby-tools/src/main/java/de/saumya/mojo/ruby/script/ScriptFactory.java
@@ -209,14 +209,24 @@ public class ScriptFactory {
         try {
             final ByteArrayOutputStream os = new ByteArrayOutputStream();
             this.newArguments().addArg("-v").execute(os);
-            final String[] versionParts = os.toString(StandardCharsets.UTF_8.toString()).split(" ");
-            final String jrubyVersion = versionParts[1];
-            final String languageVersion = extractLanguageVersion(versionParts[2]);
-            return new JRubyVersion(jrubyVersion, languageVersion);
+            String output = os.toString(StandardCharsets.UTF_8.toString());
+            final String[] lines = output.split("\n");
+            for (String line : lines) {
+                line = line.trim();
+                if (line.startsWith("jruby")) {
+                    final String[] versionParts = output.split(" ");
+                    final String jrubyVersion = versionParts[1];
+                    final String languageVersion = extractLanguageVersion(versionParts[2]);
+                    return new JRubyVersion(jrubyVersion, languageVersion);
+                }
+            }
+            logger.warn("Could not identify version from -v output: \n" + output);
         } catch (Exception e) {
             logger.warn("Could not identify version: " + e.getMessage());
-            return null;
         }
+
+        // only in cases where we cannot parse the version
+        return null;
     }
 
     private String extractLanguageVersion(String versionPart) {

--- a/ruby-tools/src/test/java/de/saumya/mojo/ruby/script/ScriptFactoryTest.java
+++ b/ruby-tools/src/test/java/de/saumya/mojo/ruby/script/ScriptFactoryTest.java
@@ -1,6 +1,7 @@
 package de.saumya.mojo.ruby.script;
 
 import org.jruby.Main;
+import org.jruby.runtime.Constants;
 import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
@@ -14,6 +15,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class ScriptFactoryTest {
 
+    private static final String BASE_JRUBY_VERSION_STRING = "jruby " + Constants.VERSION + " (" + Constants.RUBY_VERSION + ")";
+
     @Test
     public void should_execute_script_with_only_args_and_return_in_output_stream() throws ScriptException, IOException {
         Main main = new Main();
@@ -25,7 +28,7 @@ public class ScriptFactoryTest {
                 .execute(outputStream);
 
         final String output = outputStream.toString();
-        assertThat(output).startsWith("jruby 9.4.13.0 (3.1.4)");
+        assertThat(output).startsWith(BASE_JRUBY_VERSION_STRING);
     }
 
     @Test
@@ -40,7 +43,7 @@ public class ScriptFactoryTest {
 
         byte[] fileBytes = Files.readAllBytes(outputFile.toPath());
         final String output = new String(fileBytes, StandardCharsets.UTF_8);
-        assertThat(output).startsWith("jruby 9.4.13.0 (3.1.4)");
+        assertThat(output).startsWith(BASE_JRUBY_VERSION_STRING);
     }
 
     @Test
@@ -49,7 +52,7 @@ public class ScriptFactoryTest {
 
         JRubyVersion version = gemScriptFactory.getVersion();
 
-        assertThat(version.getVersion()).isEqualTo("9.4.13.0");
-        assertThat(version.getLanguage()).isEqualTo("3.1.4");
+        assertThat(version.getVersion()).isEqualTo(Constants.VERSION);
+        assertThat(version.getLanguage()).isEqualTo(Constants.RUBY_VERSION);
     }
 }

--- a/ruby-tools/src/test/java/de/saumya/mojo/ruby/script/ScriptFactoryTest.java
+++ b/ruby-tools/src/test/java/de/saumya/mojo/ruby/script/ScriptFactoryTest.java
@@ -55,4 +55,16 @@ public class ScriptFactoryTest {
         assertThat(version.getVersion()).isEqualTo(Constants.VERSION);
         assertThat(version.getLanguage()).isEqualTo(Constants.RUBY_VERSION);
     }
+
+    @Test
+    public void should_return_jruby_version_with_jdk_options_set() throws ScriptException, IOException {
+        final GemScriptFactory gemScriptFactory = gemScriptFactory();
+
+        gemScriptFactory.addEnv("JDK_JAVA_OPTIONS", "-Xmx1G");
+
+        JRubyVersion version = gemScriptFactory.getVersion();
+
+        assertThat(version.getVersion()).isEqualTo(Constants.VERSION);
+        assertThat(version.getLanguage()).isEqualTo(Constants.RUBY_VERSION);
+    }
 }


### PR DESCRIPTION
This PR makes two changes:

* Use the actual JRuby version in ScriptFactory version tests. This avoids us having to update these hardcoded strings with the JRuby version changes.
* Modify the `jruby -v` parsing to look for the line starting with `jruby`, avoiding other logging output from JRuby or the underlying JDK (#140).

This will fix #140, but I was unable to reproduce the original issue even unpatched.